### PR TITLE
Curate section photos: finished work only, matched to each section

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,6 +353,9 @@
 
                     <div class="service-grid service-grid--simple">
                         <div class="service-card">
+                            <figure class="service-photo">
+                                <img src="/assets/gallery/commercial/apartment-complex-2.webp" alt="Freshly paved asphalt drive at a residential community" width="630" height="400" loading="lazy">
+                            </figure>
                             <div class="service-hero">
                                 <div class="service-icon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.92 6.01C18.72 5.42 18.16 5 17.5 5h-11c-.66 0-1.21.42-1.42 1.01L3 12v8c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-1h12v1c0 .55.45 1 1 1h1c.55 0 1-.45 1-1v-8l-2.08-5.99zM6.5 16c-.83 0-1.5-.67-1.5-1.5S5.67 13 6.5 13s1.5.67 1.5 1.5S7.33 16 6.5 16zm11 0c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zM5 11l1.5-4.5h11L19 11H5z"/></svg></div>
                                 <div><h3>Asphalt</h3></div>
@@ -366,6 +369,9 @@
                         </div>
 
                         <div class="service-card">
+                            <figure class="service-photo">
+                                <img src="/assets/gallery/concrete/convenience-store.webp" alt="Finished concrete walkway and apron with bollards beside new asphalt" width="630" height="400" loading="lazy">
+                            </figure>
                             <div class="service-hero">
                                 <div class="service-icon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10z"/></svg></div>
                                 <div><h3>Concrete</h3></div>
@@ -392,24 +398,24 @@
                     </div>
                     <div class="work-grid">
                         <figure class="work-item">
-                            <img src="/assets/gallery/commercial/holiday-inn-express.webp" alt="New asphalt parking lot at a Holiday Inn Express hotel" width="630" height="400" loading="lazy">
-                            <figcaption>Hotel Parking Lot</figcaption>
+                            <img src="/assets/gallery/commercial/roseville-drive-thru-parking-lot.webp" alt="Finished asphalt lot at a drive-thru business" width="630" height="400" loading="lazy">
+                            <figcaption>Drive-Thru Business</figcaption>
                         </figure>
                         <figure class="work-item">
-                            <img src="/assets/gallery/commercial/hamilton-waltman-melsheimer.webp" alt="Fresh asphalt paving at a professional office complex" width="630" height="400" loading="lazy">
-                            <figcaption>Professional Offices</figcaption>
+                            <img src="/assets/gallery/commercial/cinemark-colony-square.webp" alt="Finished striped parking lot at a retail and entertainment center" width="630" height="400" loading="lazy">
+                            <figcaption>Retail &amp; Entertainment</figcaption>
                         </figure>
                         <figure class="work-item">
-                            <img src="/assets/gallery/commercial/east-pike-shopping-center.webp" alt="Paved parking lot at East Pike shopping center" width="630" height="400" loading="lazy">
-                            <figcaption>Retail Center</figcaption>
+                            <img src="/assets/gallery/commercial/church-parking-lot.webp" alt="Finished asphalt parking lot at a church campus" width="630" height="400" loading="lazy">
+                            <figcaption>Church Parking Lot</figcaption>
                         </figure>
                         <figure class="work-item">
                             <img src="/assets/gallery/commercial/apartment-complex.webp" alt="Finished asphalt drive and parking at an apartment community" width="630" height="400" loading="lazy">
                             <figcaption>Apartment Community</figcaption>
                         </figure>
                         <figure class="work-item">
-                            <img src="/assets/gallery/commercial/downtown-st-james.webp" alt="Downtown street and parking reconstruction near St. James" width="630" height="400" loading="lazy">
-                            <figcaption>Municipal Street Work</figcaption>
+                            <img src="/assets/gallery/commercial/paved-strip-mall.webp" alt="Freshly paved parking lot at a shopping center" width="630" height="400" loading="lazy">
+                            <figcaption>Shopping Center</figcaption>
                         </figure>
                         <figure class="work-item">
                             <img src="/assets/gallery/commercial/the-barn-after.webp" alt="Large finished commercial parking lot" width="630" height="400" loading="lazy">
@@ -432,12 +438,12 @@
                             <figcaption>Custom Driveway</figcaption>
                         </figure>
                         <figure class="work-item">
-                            <img src="/assets/gallery/residential/long-driveway-bridge.webp" alt="Long estate driveway with bridge crossing" width="630" height="400" loading="lazy">
-                            <figcaption>Estate Driveway</figcaption>
+                            <img src="/assets/gallery/residential/driveway-garage-door.webp" alt="Finished asphalt driveway leading to a two-car garage" width="630" height="400" loading="lazy">
+                            <figcaption>Home Driveway</figcaption>
                         </figure>
                         <figure class="work-item">
-                            <img src="/assets/gallery/residential/flagpole-driveway-country.webp" alt="Country home driveway with landscaped surroundings" width="630" height="400" loading="lazy">
-                            <figcaption>Country Driveway</figcaption>
+                            <img src="/assets/gallery/residential/pond-asphalt-driveway.webp" alt="Finished asphalt lane winding past a pond to a country home" width="630" height="400" loading="lazy">
+                            <figcaption>Private Lane</figcaption>
                         </figure>
                         <figure class="work-item">
                             <img src="/assets/gallery/residential/stone-lined-paved-driveway.webp" alt="Stone-lined asphalt driveway on a wooded lot" width="630" height="400" loading="lazy">

--- a/styles/redesign.css
+++ b/styles/redesign.css
@@ -550,6 +550,8 @@ header {
 
 /* Simplified two-card services layout */
 .service-grid--simple { max-width: 900px; margin: 0 auto 48px; }
+.service-photo { margin: 0; }
+.service-photo img { width: 100%; height: 210px; object-fit: cover; display: block; border-bottom: 1px solid var(--line); }
 .service-grid--simple .service-card { padding-bottom: 26px; }
 .service-grid--simple .service-hero h3 { font-size: 1.5rem; margin: 0; }
 .service-list { list-style: none; margin: 0; padding: 8px 28px 0; }


### PR DESCRIPTION
# Finished-work photography, matched to context

Per the owner: only photos of completed Neff Paving jobs, no employees or humans in frame, and every photo matched to the section it represents. I reviewed the full project gallery image-by-image and replaced anything showing crews, pedestrians, or active equipment.

## Commercial section (businesses & parking lots)
| Kept | Swapped in | Removed (reason) |
|---|---|---|
| Apartment Community | Drive-Thru Business | Hotel lot (scissor lift + unfinished grading in frame) |
| Commercial Lot | Retail & Entertainment center (striped lot) | Professional offices (worker raking asphalt) |
| | Church Parking Lot | Retail center (pedestrians + cones) |
| | Shopping Center | Municipal street work (skid steer + crew) |

## Residential section (homes & driveways)
- Kept: Custom Driveway, Stone-Lined Driveway
- Swapped in: **Home Driveway** (finished drive to a two-car garage) and **Private Lane** (asphalt lane winding past a pond)
- Removed: estate driveway with excavator/operator; country driveway with a worker on a roller

## Services cards
Both cards gain finished-work photo headers: a fresh asphalt drive for **Asphalt** and a concrete apron/walkway with bollards for **Concrete** (new `.service-photo` styles).

All images are existing project photos from `assets/gallery/` — no new assets. Build passes and the sections were screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fCWZZG1gCWgLugd3bin64

---
_Generated by [Claude Code](https://claude.ai/code/session_016fCWZZG1gCWgLugd3bin64)_

## Summary by Sourcery

Update site imagery to showcase finished work aligned to each section’s context.

New Features:
- Add header photos to Asphalt and Concrete service cards using curated gallery images.

Enhancements:
- Refresh commercial gallery items to depict completed parking lots and business properties without active crews.
- Refresh residential gallery items to highlight finished driveways and lanes at homes.
- Add styling for service card header photos to ensure consistent, cropped presentation.