### PR TITLE
perf(cls): fix ~1.0 hero layout shift (mobile-nav in critical CSS)

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,11 @@
     .header-phone{display:inline-flex;align-items:center;gap:9px;font-family:var(--font-head);font-weight:600;letter-spacing:1px;color:var(--text);font-size:15px;white-space:nowrap}
     .mobile-menu-toggle{display:none;flex-direction:column;gap:5px;background:none;border:0;cursor:pointer;padding:8px}
     .mobile-menu-toggle .hamburger-line{width:26px;height:2px;background:var(--text);border-radius:2px}
+    /* Keep the off-canvas drawer + overlay out of flow from first paint. Without these,
+       the unstyled drawer renders in-flow above the hero until the deferred redesign.css
+       loads, then collapses — a full-viewport layout shift (CLS ~1.0). */
+    .mobile-nav{position:fixed;top:0;right:-100%;width:min(360px,86vw);height:100vh;z-index:1200;overflow-y:auto}
+    .mobile-nav-overlay{position:fixed;inset:0;z-index:1100;opacity:0;visibility:hidden}
     #hero{position:relative;min-height:100vh;display:flex;align-items:center;padding:140px 0 90px;overflow:hidden}
     #hero-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:0;opacity:0}
     .hero-poster{position:absolute;inset:0;width:100%;height:100%;z-index:0}


### PR DESCRIPTION
## Problem
Mobile Lighthouse showed a **stable CLS of 1.018** — the single biggest drag on the mobile PageSpeed score. Root cause traced with Playwright LayoutShift attribution + Lighthouse filmstrip:

The `.mobile-nav` drawer + `.mobile-nav-overlay` sit in the DOM before `<main>`, but their `position:fixed` off-canvas rules live only in the **deferred** `redesign.css` (loaded async via the `media=print` swap). Until it applies, the unstyled drawer renders **in normal flow above the hero** (~a full viewport of links/contact/social), pushing the hero down. When `redesign.css` loads and pulls the drawer off-canvas, the hero collapses upward → the full-viewport `.hero-overlay` resizes → **CLS ≈ 1.0**.

(Font swap was a red herring — `font-display:optional` did *not* fix it; the shift reproduces with fonts locked.)

## Fix
Hoist the minimal off-canvas positioning for `.mobile-nav` and `.mobile-nav-overlay` into the inline **critical CSS**, so the drawer is out of flow from the first paint. Values mirror `redesign.css` exactly (later stylesheet = no-op for these).

## Measured (production build, mobile, 4× CPU / Slow 4G)
| | Before | After |
|---|--------|-------|
| **CLS** | 1.018 | **0.019** |
| **Perf score** | 75 | **91–98** |

TBT (30ms), LCP (2.0s), FCP (1.2s) were already green — CLS was the lone code defect.

> Note: the *live* mobile score is additionally capped by edge-injected third parties (Google Tag Manager via Cloudflare ≈ 1.3s main-thread, Cloudflare Insights, apex→www redirect) that are not in this repo. Those are tracked separately.

## Summary by Sourcery

Enhancements:
- Inline minimal fixed-position off-canvas styles for the mobile navigation and its overlay into critical CSS to keep them out of normal document flow from first paint.